### PR TITLE
tmux: flat two-tone status bar with git indicators

### DIFF
--- a/assets/tmux-theme-dark.conf
+++ b/assets/tmux-theme-dark.conf
@@ -1,14 +1,16 @@
 # MANGANESE DARK THEME
-# Status bar configuration
-set -g status-style bg='#232323',fg='#f8f5f0'
-set -g status-left '#[fg=#232323,bg=#ff7900,bold] #S #[fg=#ff7900,bg=#404040,nobold]#[fg=#f8f5f0,bg=#404040,bold] #(whoami) #[fg=#404040,bg=#232323,nobold]'
-set -g status-right '#[fg=#404040,bg=#232323,nobold]#[fg=#f8f5f0,bg=#404040] %Y-%m-%d %H:%M #[fg=#ff7900,bg=#404040,nobold]#[fg=#232323,bg=#ff7900,bold] #H '
-set -g status-right-length 50
+# Two-tone status bar: darker top, lighter bottom
+
+# Line 1 - solid dark gray
+set -g status-style bg='#2d2d2d',fg='#f8f5f0'
+set -g status-left '#[fg=#ff7900,bg=#2d2d2d,bold] #S #[fg=#888888,nobold]| #[fg=#d9d5d0]#(whoami) '
+set -g status-right ' #[fg=#d9d5d0,bg=#2d2d2d]%Y-%m-%d %H:%M:%S #[fg=#888888]| #[fg=#ff7900,bold]#H '
+set -g status-right-length 60
 set -g status-left-length 30
 
-# Window status
-setw -g window-status-current-format '#[fg=#232323,bg=#0079ff]#[fg=#f8f5f0,bg=#0079ff,noreverse,bold] #I: #W #[fg=#0079ff,bg=#232323,nobold]'
-setw -g window-status-format '#[fg=#232323,bg=#404040]#[fg=#d9d5d0,bg=#404040] #I: #W #[fg=#404040,bg=#232323]'
+# Window status - same bg, text accents only
+setw -g window-status-current-format '#[fg=#0079ff,bg=#2d2d2d,bold] #I: #W #[nobold]'
+setw -g window-status-format '#[fg=#888888,bg=#2d2d2d] #I: #W '
 
 # Pane borders
 set -g pane-border-style fg='#404040'
@@ -24,8 +26,8 @@ setw -g clock-mode-colour '#0079ff'
 # Copy mode colours
 set-window-option -g mode-style bg='#404040',fg='#f8f5f0'
 
-# Window activity style - subtle highlight
-set -g window-status-activity-style bg='#232323',fg='#cc3300'
+# Window activity style
+set -g window-status-activity-style bg='#2d2d2d',fg='#cc3300'
 
-# Second status line - working directory and git context
-set -g status-format[1] '#[align=left]#[fg=#d9d5d0,bg=#232323] #{=60:pane_current_path} #[align=right]#[fg=#0079ff,bg=#232323]#(cd #{pane_current_path} && git symbolic-ref --short HEAD 2>/dev/null) #[fg=#ff7900]#(cd #{pane_current_path} && git diff --quiet HEAD 2>/dev/null || echo "*") '
+# Line 2 - lighter gray strip with path + git
+set -g status-format[1] '#[fill=#383838]#[align=left]#[fg=#aaaaaa,bg=#383838] #(echo #{pane_current_path} | sed "s|^$HOME|~|") #[align=right]#[fg=#4a7a9b,bg=#383838]#(cd #{pane_current_path} && git symbolic-ref --short HEAD 2>/dev/null)#[fg=#cc6633]#(cd #{pane_current_path} && ! git diff --quiet 2>/dev/null && echo " ∆")#[fg=#cc3333]#(cd #{pane_current_path} && git ls-files --other --exclude-standard 2>/dev/null | head -1 | grep -q . && echo " ⊕")#[fg=#669966]#(cd #{pane_current_path} && ! git diff --cached --quiet 2>/dev/null && echo " ∙") '

--- a/assets/tmux-theme-light.conf
+++ b/assets/tmux-theme-light.conf
@@ -1,20 +1,22 @@
 # MANGANESE LIGHT THEME
-# Status bar configuration
-set -g status-style bg='#f8f5f0',fg='#232323'
-set -g status-left '#[fg=#f8f5f0,bg=#ff7900,bold] #S #[fg=#ff7900,bg=#d9d5d0,nobold]#[fg=#232323,bg=#d9d5d0,bold] #(whoami) #[fg=#d9d5d0,bg=#f8f5f0,nobold]'
-set -g status-right '#[fg=#d9d5d0,bg=#f8f5f0,nobold]#[fg=#232323,bg=#d9d5d0] %Y-%m-%d %H:%M #[fg=#ff7900,bg=#d9d5d0,nobold]#[fg=#f8f5f0,bg=#ff7900,bold] #H '
-set -g status-right-length 50
+# Two-tone status bar: lighter top, darker bottom
+
+# Line 1 - solid light gray
+set -g status-style bg='#d9d5d0',fg='#232323'
+set -g status-left '#[fg=#ff7900,bg=#d9d5d0,bold] #S #[fg=#999999,nobold]| #[fg=#444444]#(whoami) '
+set -g status-right ' #[fg=#444444,bg=#d9d5d0]%Y-%m-%d %H:%M:%S #[fg=#999999]| #[fg=#ff7900,bold]#H '
+set -g status-right-length 60
 set -g status-left-length 30
 
-# Window status
-setw -g window-status-current-format '#[fg=#f8f5f0,bg=#0079ff]#[fg=#f8f5f0,bg=#0079ff,noreverse,bold] #I: #W #[fg=#0079ff,bg=#f8f5f0,nobold]'
-setw -g window-status-format '#[fg=#f8f5f0,bg=#d9d5d0]#[fg=#404040,bg=#d9d5d0] #I: #W #[fg=#d9d5d0,bg=#f8f5f0]'
+# Window status - same bg, text accents only
+setw -g window-status-current-format '#[fg=#0079ff,bg=#d9d5d0,bold] #I: #W #[nobold]'
+setw -g window-status-format '#[fg=#888888,bg=#d9d5d0] #I: #W '
 
 # Pane borders
 set -g pane-border-style fg='#d9d5d0'
 set -g pane-active-border-style fg='#ff7900'
 
-# Message style - make them stand out more
+# Message style
 set -g message-style bg='#ff7900',fg='#f8f5f0',bold
 set -g message-command-style bg='#d9d5d0',fg='#232323'
 
@@ -24,8 +26,8 @@ setw -g clock-mode-colour '#0079ff'
 # Copy mode colours
 set-window-option -g mode-style bg='#ffcc99',fg='#232323'
 
-# Window activity style - subtle highlight
-set -g window-status-activity-style bg='#f8f5f0',fg='#cc3300'
+# Window activity style
+set -g window-status-activity-style bg='#d9d5d0',fg='#cc3300'
 
-# Second status line - working directory and git context
-set -g status-format[1] '#[align=left]#[fg=#404040,bg=#f8f5f0] #{=60:pane_current_path} #[align=right]#[fg=#0079ff,bg=#f8f5f0]#(cd #{pane_current_path} && git symbolic-ref --short HEAD 2>/dev/null) #[fg=#ff7900]#(cd #{pane_current_path} && git diff --quiet HEAD 2>/dev/null || echo "*") '
+# Line 2 - darker gray strip with path + git
+set -g status-format[1] '#[fill=#ccc8c2]#[align=left]#[fg=#444444,bg=#ccc8c2] #(echo #{pane_current_path} | sed "s|^$HOME|~|") #[align=right]#[fg=#1a5599,bg=#ccc8c2]#(cd #{pane_current_path} && git symbolic-ref --short HEAD 2>/dev/null)#[fg=#cc6600]#(cd #{pane_current_path} && ! git diff --quiet 2>/dev/null && echo " ∆")#[fg=#cc2222]#(cd #{pane_current_path} && git ls-files --other --exclude-standard 2>/dev/null | head -1 | grep -q . && echo " ⊕")#[fg=#227722]#(cd #{pane_current_path} && ! git diff --cached --quiet 2>/dev/null && echo " ∙") '


### PR DESCRIPTION
Redesign both Manganese themes:

- Remove powerline segments, use flat two-tone gray bars
- Top line: session, windows, clock with text-only accents  
- Bottom line: path (~-shortened) + git status (∆ ⊕ ∙)
- Add seconds to clock display
- Consistent styling across dark and light themes