### PR TITLE
tmux: persistent bell dot in window status for both themes

### DIFF
--- a/assets/tmux-base.conf
+++ b/assets/tmux-base.conf
@@ -125,7 +125,10 @@ bind C-l clear-history \; display-message -d 2000 "History cleared"
 set -g allow-passthrough on
 
 # When a background window rings the bell, flag it in the status bar
-# instead of beeping or printing a message
+# instead of beeping or printing a message. The persistent dot indicator
+# next to the window name is drawn per-theme via #{?window_bell_flag,...}
+# in window-status-format (see tmux-theme-{dark,light}.conf), because the
+# themes' hardcoded fg/bg would otherwise override window-status-bell-style.
 set -g monitor-bell on
 set -g bell-action other
 set -g visual-bell off

--- a/assets/tmux-theme-dark.conf
+++ b/assets/tmux-theme-dark.conf
@@ -9,8 +9,11 @@ set -g status-right-length 60
 set -g status-left-length 30
 
 # Window status - same bg, text accents only
-setw -g window-status-current-format '#[fg=#0079ff,bg=#2d2d2d,bold] #I: #W #[nobold]'
-setw -g window-status-format '#[fg=#888888,bg=#2d2d2d] #I: #W '
+# Bell flag (#{?window_bell_flag,...}) adds a persistent red dot after the
+# window name; it survives the hardcoded fg/bg above (which would otherwise
+# clobber window-status-bell-style) and clears when the window is selected.
+setw -g window-status-current-format '#[fg=#0079ff,bg=#2d2d2d,bold] #I: #W#{?window_bell_flag,#[fg=#ff5f5f] ●,} #[nobold]'
+setw -g window-status-format '#[fg=#888888,bg=#2d2d2d] #I: #W#{?window_bell_flag,#[fg=#ff5f5f] ●,} '
 
 # Pane borders
 set -g pane-border-style fg='#404040'

--- a/assets/tmux-theme-light.conf
+++ b/assets/tmux-theme-light.conf
@@ -9,8 +9,11 @@ set -g status-right-length 60
 set -g status-left-length 30
 
 # Window status - same bg, text accents only
-setw -g window-status-current-format '#[fg=#0079ff,bg=#d9d5d0,bold] #I: #W #[nobold]'
-setw -g window-status-format '#[fg=#888888,bg=#d9d5d0] #I: #W '
+# Bell flag (#{?window_bell_flag,...}) adds a persistent red dot after the
+# window name; it survives the hardcoded fg/bg above (which would otherwise
+# clobber window-status-bell-style) and clears when the window is selected.
+setw -g window-status-current-format '#[fg=#0079ff,bg=#d9d5d0,bold] #I: #W#{?window_bell_flag,#[fg=#cc2222] ●,} #[nobold]'
+setw -g window-status-format '#[fg=#888888,bg=#d9d5d0] #I: #W#{?window_bell_flag,#[fg=#cc2222] ●,} '
 
 # Pane borders
 set -g pane-border-style fg='#d9d5d0'


### PR DESCRIPTION
The bell already flagged background windows (monitor-bell on, bell-action other), but the only visual cue was the transient visual-bell flash. window-status-bell-style had no effect because each theme's window-status-format hardcodes fg/bg, overriding it.

Add a theme-aware persistent indicator via #{?window_bell_flag,...} baked directly into both window-status-format strings, so a red dot appears next to the window index/name when a background window rings the bell and clears when that window is selected. Colours match each palette: #ff5f5f on dark, #cc2222 on light.