### PR TITLE
tmux: disable visual-activity flash, keep persistent bell dot

### DIFF
--- a/assets/tmux-base.conf
+++ b/assets/tmux-base.conf
@@ -86,8 +86,12 @@ setw -g mode-keys emacs
 bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-selection-and-cancel
 
 # Activity monitoring
+# monitor-activity still flags windows (window-status-activity-style), but
+# visual-activity is off: the transient status-bar flash is redundant now
+# that a bell raises a persistent dot, and the flash fired on bell anyway
+# (the bell's pane output trips activity monitoring).
 setw -g monitor-activity on
-set -g visual-activity on
+set -g visual-activity off
 # Bell behaviour is set below in the "Claude Code attention signal" block
 
 # Renumber windows when one is closed


### PR DESCRIPTION
The status-bar flash on bell wasn't visual-bell (already off) — it was visual-activity: a ringing bell produces pane output that trips monitor-activity, and visual-activity on flashes an activity message across the status line. With the persistent window-status bell dot in place that flash is redundant and distracting.

Set visual-activity off. monitor-activity stays on so windows still carry the activity style; only the transient bar flash is removed.